### PR TITLE
Updated badges for travis and codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Moodster API Project
 
-[![Build Status](https://travis-ci.com/JBonser/moodster-api-new.svg?branch=master)](https://travis-ci.com/JBonser/moodster-api-new)
-[![codecov](https://codecov.io/gh/JBonser/moodster-api-new/branch/master/graph/badge.svg)](https://codecov.io/gh/JBonser/moodster-api-new)
+[![Build Status](https://travis-ci.com/Schwepp/moodster-api.svg?branch=master)](https://travis-ci.com/Schwepp/moodster-api)
+[![codecov](https://codecov.io/gh/Schwepp/moodster-api/branch/master/graph/badge.svg)](https://codecov.io/gh/Schwepp/moodster-api)
 
 ## Running the Application
 


### PR DESCRIPTION
Had to update the badges as they pointed to the old repo's.

May still need to update the upload token for the codecov in the travis run, but I'll kick it off and see first.